### PR TITLE
Added missing <tuple> include

### DIFF
--- a/include/boost/variant/detail/multivisitors_cpp14_based.hpp
+++ b/include/boost/variant/detail/multivisitors_cpp14_based.hpp
@@ -18,6 +18,7 @@
 #endif
 
 #include <boost/variant/detail/multivisitors_cpp14_based.hpp>
+#include <tuple>
 
 namespace boost {
 


### PR DESCRIPTION
This makes the header able to be built standalone, making possible C++ clang modules builds.
